### PR TITLE
保証種別削除機能実装

### DIFF
--- a/backend/app/controllers/api/guarantee_types_controller.rb
+++ b/backend/app/controllers/api/guarantee_types_controller.rb
@@ -34,7 +34,6 @@ class Api::GuaranteeTypesController < ApplicationController
   end
 
   def destroy
-    Guarantee.delete_all(guarantee_type: @guarantee_type)
     if @guarantee_type.destroy
       render json: {result: "success"}
     else

--- a/backend/app/models/guarantee_type.rb
+++ b/backend/app/models/guarantee_type.rb
@@ -27,6 +27,7 @@ class GuaranteeType < ApplicationRecord
   }.with_indifferent_access.freeze
 
   # Relations
+  has_many :guarantees, dependent: :destroy
 
   # Validations
   validates :name, presence: true, length: { maximum: 255 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -82,6 +82,7 @@
     "ie-shim": "^0.1.0",
     "jquery": "^1.9.1",
     "less": "^2.7.1",
+    "ng2-bootstrap": "^1.1.5",
     "ng2-search-table": "^1.0.0",
     "ng2-toastr": "^1.1.0",
     "object-assign": "^4.1.0",

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,7 +1,7 @@
 /*
  * Angular 2 decorators and services
  */
-import { Component, ViewEncapsulation } from '@angular/core';
+import {Component, ViewEncapsulation, ViewContainerRef} from '@angular/core';
 
 import { AppState } from './app.service';
 
@@ -22,4 +22,9 @@ import { AppState } from './app.service';
   `
 })
 export class App {
+  private viewContainerRef: ViewContainerRef;
+
+  public constructor(viewContainerRef: ViewContainerRef) {
+    this.viewContainerRef = viewContainerRef;
+  }
 }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -26,6 +26,7 @@ import {ToastModule} from 'ng2-toastr';
 import {SimpleForm} from './common/simple-form/simple-form.component';
 import {SimpleFormInput} from './common/simple-form/simple-form-input.component';
 import {EditGuaranteeType} from './guarantee-type/edit-guarantee-type/edit-guarantee-type.component';
+import {ModalDirective} from 'ng2-bootstrap';
 
 // Application wide providers
 const APP_PROVIDERS = [
@@ -62,7 +63,8 @@ type StoreType = {
     HttpModule,
     RouterModule.forRoot(ROUTES, { useHash: true }),
     Ng2SearchTableModule.forRoot(),
-    ToastModule
+    ToastModule,
+    ModalDirective
   ],
   providers: [ // expose our Services and Providers into Angular's dependency injection
     ENV_PROVIDERS,

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -26,7 +26,7 @@ import {ToastModule} from 'ng2-toastr';
 import {SimpleForm} from './common/simple-form/simple-form.component';
 import {SimpleFormInput} from './common/simple-form/simple-form-input.component';
 import {EditGuaranteeType} from './guarantee-type/edit-guarantee-type/edit-guarantee-type.component';
-import {ModalDirective} from 'ng2-bootstrap';
+import {ModalDirective, ModalModule} from 'ng2-bootstrap';
 
 // Application wide providers
 const APP_PROVIDERS = [
@@ -64,7 +64,7 @@ type StoreType = {
     RouterModule.forRoot(ROUTES, { useHash: true }),
     Ng2SearchTableModule.forRoot(),
     ToastModule,
-    ModalDirective
+    ModalModule
   ],
   providers: [ // expose our Services and Providers into Angular's dependency injection
     ENV_PROVIDERS,

--- a/frontend/src/app/guarantee-type/edit-guarantee-type/edit-guarantee-type.component.ts
+++ b/frontend/src/app/guarantee-type/edit-guarantee-type/edit-guarantee-type.component.ts
@@ -2,7 +2,7 @@ import {Component, ViewChild} from '@angular/core';
 import {GuaranteeTypeForm} from '../../models/guarantee-type-form';
 import {GuaranteeTypeService} from '../guarantee-type.service';
 import {ToastsManager} from 'ng2-toastr';
-import {ActivatedRoute} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {SimpleForm} from '../../common/simple-form/simple-form.component';
 
 @Component({
@@ -20,7 +20,8 @@ export class EditGuaranteeType {
   constructor(
     private guaranteeTypeService: GuaranteeTypeService,
     private toastr: ToastsManager,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private router: Router
   ) {
     this.route.params.subscribe(p => this.formId = p['id']);
   }
@@ -65,5 +66,22 @@ export class EditGuaranteeType {
           }
         );
     }
+  }
+
+  deleteGuaranteeType(modal: any): void {
+    modal.hide();
+
+    this
+      .guaranteeTypeService
+      .destroy(this.formId)
+      .subscribe(
+        _ => {
+          this.toastr.success("削除しました。", "Success");
+          this.router.navigate(['guarantee-types']);
+        },
+        _ => {
+          this.toastr.error("削除に失敗しました。", "Error");
+        }
+      );
   }
 }

--- a/frontend/src/app/guarantee-type/edit-guarantee-type/edit-guarantee-type.template.html
+++ b/frontend/src/app/guarantee-type/edit-guarantee-type/edit-guarantee-type.template.html
@@ -52,7 +52,7 @@
         <button type="button" class="btn btn-default" data-dismiss="modal" (click)="deleteModal.hide()">
           Close
         </button>
-        <button type="button" class="btn btn-danger" (click)="deleteGuaranteeType()">削除する</button>
+        <button type="button" class="btn btn-danger" (click)="deleteGuaranteeType(deleteModal)">削除する</button>
       </div>
     </div>
   </div>

--- a/frontend/src/app/guarantee-type/edit-guarantee-type/edit-guarantee-type.template.html
+++ b/frontend/src/app/guarantee-type/edit-guarantee-type/edit-guarantee-type.template.html
@@ -11,13 +11,16 @@
 
 <div class="row" *ngIf="guaranteeTypeForm">
   <simple-form [form]="guaranteeTypeForm" (submit)="formSubmit()" #form>
-    <div class="col-xs-12 text-right">
+    <div class="col-xs-6">
+      <a class="btn btn-normal">Delete</a>
+    </div>
+    <div class="col-xs-6 text-right">
       <label *ngIf="form.dirty()" class="label label-warning mr-10">Unsaved</label>
       <button type="submit" class="btn btn-primary"
               [disabled]="!form.valid() || submitLocked">Save</button>
     </div>
 
-    <div class="col-xs-12">
+    <div class="col-xs-12 mt-10">
       <simple-form-input [name]='"name"' [type]='"text"'
                          [labelDisplayName]="'Name'"
                          [placeholder]='"保証種別名を入力してください。"'>
@@ -29,3 +32,5 @@
     </div>
   </simple-form>
 </div>
+
+<confirm-modal></confirm-modal>

--- a/frontend/src/app/guarantee-type/edit-guarantee-type/edit-guarantee-type.template.html
+++ b/frontend/src/app/guarantee-type/edit-guarantee-type/edit-guarantee-type.template.html
@@ -12,12 +12,12 @@
 <div class="row" *ngIf="guaranteeTypeForm">
   <simple-form [form]="guaranteeTypeForm" (submit)="formSubmit()" #form>
     <div class="col-xs-6">
-      <a class="btn btn-normal">Delete</a>
+      <a class="btn btn-normal" (click)="deleteModal.show()">削除</a>
     </div>
     <div class="col-xs-6 text-right">
       <label *ngIf="form.dirty()" class="label label-warning mr-10">Unsaved</label>
       <button type="submit" class="btn btn-primary"
-              [disabled]="!form.valid() || submitLocked">Save</button>
+              [disabled]="!form.valid() || submitLocked">保存</button>
     </div>
 
     <div class="col-xs-12 mt-10">
@@ -33,4 +33,27 @@
   </simple-form>
 </div>
 
-<confirm-modal></confirm-modal>
+<!-- 削除モーダル -->
+<div bsModal #deleteModal="bs-modal" class="modal fade"
+     tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" (click)="deleteModal.hide()" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">削除確認</h4>
+      </div>
+      <div class="modal-body">
+        種別を削除すると、紐づく補償額設定も削除されます。<br>
+        保証種別 ID:{{formId}} を削除してもよろしいですか。
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal" (click)="deleteModal.hide()">
+          Close
+        </button>
+        <button type="button" class="btn btn-danger" (click)="deleteGuaranteeType()">削除する</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/guarantee-type/guarantee-type.service.ts
+++ b/frontend/src/app/guarantee-type/guarantee-type.service.ts
@@ -43,4 +43,10 @@ export class GuaranteeTypeService {
       ._http
       .put(process.env.API_URL + "/api/guarantee_types/" + id, body);
   }
+
+  destroy(id: string): any {
+    return this
+      ._http
+      .delete(process.env.API_URL + '/api/guarantee_types/' + id);
+  }
 }

--- a/frontend/src/app/guarantee-type/new-guarantee-type/new-guarantee-type.template.html
+++ b/frontend/src/app/guarantee-type/new-guarantee-type/new-guarantee-type.template.html
@@ -14,7 +14,7 @@
   <div class="col-xs-12 text-right">
     <label *ngIf="form.dirty()" class="label label-warning mr-10">Unsaved</label>
     <button type="submit" class="btn btn-primary"
-            [disabled]="!form.valid() || submitLocked">Save</button>
+            [disabled]="!form.valid() || submitLocked">保存</button>
   </div>
 
   <div class="col-xs-12">


### PR DESCRIPTION
これで種別は一通り終わり。
次は補償額設定を実装する。

![sshot 2016-09-21 2 26 14](https://cloud.githubusercontent.com/assets/818452/18681438/07bea642-7fa3-11e6-8966-22a1c9c51fed.png)
